### PR TITLE
Include default headers

### DIFF
--- a/examples/simple_ua.pl
+++ b/examples/simple_ua.pl
@@ -1,6 +1,8 @@
 use LWP::UserAgent::Caching;
 use CHI;
 
+# use LWP::ConsoleLogger::Everywhere;
+
 my $chi_cache = CHI->new(
     driver          => 'File',
     root_dir        => '/tmp/LWP_UserAgent_Caching',
@@ -22,8 +24,12 @@ my $ua = LWP::UserAgent::Caching->new(
     http_caching => {
         cache           => $chi_cache,
     #   cache_meta      => $chi_cache_meta,
+        request_directives => "no-transform, add-on-top=true, max-stale", # uhm ... no-transform ???
     },
 );
+
+$ua->default_header('X-Module' => __PACKAGE__ );
+$ua->default_header('Cache-Control' => 'unknown' );
 
 $HTTP::Caching::DEBUG = 1;
 
@@ -35,14 +41,8 @@ print "\n#####\n";
 print "\nGETTING\n";
 print "\n#####\n";
 
-
-    my $resp = $ua->get($url);
+    my $resp = $ua->get($url, 'Cache-Control' => 'min-fresh=30' );
     print $resp->headers->as_string;
-#    exit
+    print "\n";
+    print $resp->request()->headers()->as_string;
 }
-
-my $http_request = HTTP::Request->new( $method, $url );
-
-my $http_response = $ua->request($http_request);
-
-print $http_response->headers->as_string;

--- a/lib/LWP/UserAgent/Caching.pm
+++ b/lib/LWP/UserAgent/Caching.pm
@@ -90,8 +90,10 @@ sub new {
 }
 
 sub request {
-    $_[1]->headers->user_agent( $_[0]->agent ); # FIX: only set during request
-    return shift->{http_caching}->make_request(@_);
+    my $self = shift;
+    my $rqst = shift->clone;
+    $self->prepare_request($rqst);
+    return $self->{http_caching}->make_request($rqst, @_);
 }
 
 


### PR DESCRIPTION
Include all headers in the request, so our cache knows about them and keeps them stored.

`LWP::Useragent` usually adds them at a later stage